### PR TITLE
Decorate objects in Hash recursively

### DIFF
--- a/lib/active_decorator/decorator.rb
+++ b/lib/active_decorator/decorator.rb
@@ -29,6 +29,10 @@ module ActiveDecorator
         obj.each do |r|
           decorate r
         end
+      elsif obj.is_a?(Hash)
+        obj.values.each do |v|
+          decorate v
+        end
       elsif defined?(ActiveRecord) && obj.is_a?(ActiveRecord::Relation)
         # don't call each nor to_a immediately
         if obj.respond_to?(:records)

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -31,4 +31,23 @@ class DecoratorTest < Test::Unit::TestCase
     books = Book.all
     assert_equal books, ActiveDecorator::Decorator.instance.decorate(ActiveDecorator::Decorator.instance.decorate(books))
   end
+
+  test 'it returns the object of Hash on decoration' do
+    book_in_hash = { some_record: Book.new(title: 'Boek') }
+    assert_equal book_in_hash, ActiveDecorator::Decorator.instance.decorate(book_in_hash)
+  end
+
+  test 'it returns the object of Hash when it already is decorated on decorate' do
+    book_in_hash = { some_record: Book.new(title: 'Boek') }
+    assert_equal book_in_hash, ActiveDecorator::Decorator.instance.decorate(ActiveDecorator::Decorator.instance.decorate(book_in_hash))
+  end
+
+  test 'The object in Hash has all the methods included by its Decorator' do
+    book = Book.new(title: 'Boek')
+    ActiveDecorator::Decorator.instance.decorate(some_record: book)
+    decorator = ActiveDecorator::Decorator.instance
+                                          .send(:decorator_for, book.class)
+
+    assert(decorator.instance_methods.all? { |d| book.methods.include?(d) })
+  end
 end


### PR DESCRIPTION
## Summary

This is a feature request. I added another condition for decorating objects in Hash values. Recently I came across a situation where I need to `group_by` ActiveRecord::Relation in Controller action and pass it to View. So I reckon that it would be more friendly to dig into Hash values recursively to check if there are any ActiveRecord models / ActiveRecord::Relation inside them.

Here is a sample code: https://github.com/FumiyaShibusawa/active-decorator-hash-sample